### PR TITLE
Include options

### DIFF
--- a/brewfile.py
+++ b/brewfile.py
@@ -1,7 +1,21 @@
 import os
+import re
 import subprocess
 
 import dotbot
+
+
+INCLUDE_OPTIONS = ['tap', 'brew', 'cask', 'mas']
+BREWFILE_LINE = re.compile(
+    r"""
+    ^
+        (?P<type>(tap|brew|cask|mas))\s*  # dependency type
+        "(?P<name>.*)"\s*                 # name between quotes
+        (,\s*id:\s*(?P<id>\d\d*)\s*)?     # id for mas items
+    $
+    """,
+    re.MULTILINE | re.VERBOSE
+)
 
 
 class Brew(dotbot.Plugin):
@@ -16,6 +30,7 @@ class Brew(dotbot.Plugin):
     _default_filename = 'Brewfile'
     _default_stdout = False
     _default_stderr = False
+    _default_include = INCLUDE_OPTIONS
 
     # API methods
 
@@ -49,9 +64,13 @@ class Brew(dotbot.Plugin):
             return {'file': data}
         return data
 
+    def _brewfile_path(self, data):
+        return os.path.join(
+            self.cwd, data.get('file', self._default_filename)
+        )
+
     def _does_brewfile_exist(self, data):
-        path = os.path.join(
-            self.cwd, data.get('file', self._default_filename))
+        path = self._brewfile_path(data)
         return os.path.isfile(path)
 
     def _build_command(self, command, data):
@@ -65,6 +84,39 @@ class Brew(dotbot.Plugin):
                 options.append(build_option(key, value))
 
         return ' '.join(options)
+
+    def _get_includes(self, data):
+        includes = data.get('include', self._default_include)
+
+        if isinstance(includes, str):
+            includes = [includes]
+
+        unknown = set(includes) - set(INCLUDE_OPTIONS)
+
+        if unknown:
+            raise ValueError('Unknown include(s) provided', unknown)
+
+        return includes
+
+    def _build_environs(self, data):
+        includes = self._get_includes(data)
+        environs = {}
+
+        with open(self._brewfile_path(data)) as f:
+            contense = f.read()
+
+        for match in BREWFILE_LINE.finditer(contense):
+            type_, name, id_ = match.group('type', 'name', 'id')
+
+            if type_ not in includes:
+                env_name = 'HOMEBREW_BUNDLE_{}_SKIP'.format(type_.upper())
+                skips = environs.setdefault(env_name, [])
+                skips.append(id_ or name)  # prefer id when available
+
+        environs = {k: ' '.join(v) for k, v in environs.items()}
+
+        return environs
+
 
     # Handlers
 
@@ -90,6 +142,7 @@ class Brew(dotbot.Plugin):
                 raise ValueError('Failed to tap homebrew/bundle.')
 
     def _handle_install(self, data):
+        environs = self._build_environs(data)
         full_command = self._build_command(self._install_command, data)
         stdout, stderr = self._get_options(data)
 
@@ -100,6 +153,7 @@ class Brew(dotbot.Plugin):
                 stdin=devnull,
                 stdout=True if stdout else devnull,
                 stderr=True if stderr else devnull,
+                env=environs,
                 cwd=self.cwd,
             )
 

--- a/brewfile.py
+++ b/brewfile.py
@@ -80,7 +80,7 @@ class Brew(dotbot.Plugin):
         options = [command]
 
         for key, value in data.items():
-            if key not in ('stdout', 'stderr'):
+            if key not in ('stdout', 'stderr', 'include'):
                 options.append(build_option(key, value))
 
         return ' '.join(options)
@@ -100,7 +100,7 @@ class Brew(dotbot.Plugin):
 
     def _build_environs(self, data):
         includes = self._get_includes(data)
-        environs = {}
+        ignores = {}
 
         with open(self._brewfile_path(data)) as f:
             contense = f.read()
@@ -110,10 +110,14 @@ class Brew(dotbot.Plugin):
 
             if type_ not in includes:
                 env_name = 'HOMEBREW_BUNDLE_{}_SKIP'.format(type_.upper())
-                skips = environs.setdefault(env_name, [])
+                skips = ignores.setdefault(env_name, [])
                 skips.append(id_ or name)  # prefer id when available
 
-        environs = {k: ' '.join(v) for k, v in environs.items()}
+
+        ignores = {k: ' '.join(v) for k, v in ignores.items()}
+
+        environs = dict(os.environ)
+        environs.update(ignores)
 
         return environs
 

--- a/brewfile.py
+++ b/brewfile.py
@@ -96,7 +96,7 @@ class Brew(dotbot.Plugin):
         if unknown:
             raise ValueError('Unknown include(s) provided', unknown)
 
-        return includes
+        return set(includes)
 
     def _build_environs(self, data):
         includes = self._get_includes(data)


### PR DESCRIPTION
Added a include option to whitelist dependancy types (tap, brew, cask, & mas).

See #2