### PR TITLE
Fix bundle flags

### DIFF
--- a/brewfile.py
+++ b/brewfile.py
@@ -75,7 +75,12 @@ class Brew(dotbot.Plugin):
 
     def _build_command(self, command, data):
         def build_option(name, value):
-            return '='.join(['--' + name, str(value)])
+            option = '--' + name
+
+            if name != 'file':
+                return option
+
+            return f'{option}={value}'
 
         options = [command]
 

--- a/example.yaml
+++ b/example.yaml
@@ -1,3 +1,3 @@
-- brewfile: 
+- brewfile:
     file: Brewfile
-    no-upgrage: true
+    no-upgrade: true


### PR DESCRIPTION
`brew bundle` command takes only flags (e.g. arguments without values) except `--file=` option.

You can use `brew help bundle` for more info.