### PR TITLE
Removed f-string for Python2 Compatibility

### DIFF
--- a/brewfile.py
+++ b/brewfile.py
@@ -80,7 +80,7 @@ class Brew(dotbot.Plugin):
             if name != 'file':
                 return option
 
-            return f'{option}={value}'
+            return '%s=%s' % (option, value)
 
         options = [command]
 


### PR DESCRIPTION
I was getting a syntax error when trying to do a fresh install on MacOS due to the f-string. Python3 is not the default python on MacOS (as of 10.15.5) so it makes sense to switch back to the older style for compatibility reasons. This way bootstrapping should work without any other configuration dependencies.

Somewhat related, when dotbot selects which version of python to use, it defaults to 'python' over 'python3'. So even if you have python3 installed it will use the 2.7 Mac system version unless you have it aliased or the path changed.

Cheers!