### PR TITLE
Allow running brew as another user

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ git submodule add https://github.com/sobolevn/dotbot-brewfile.git
       stdout: false
       stderr: false
       include: ['tap', 'brew', 'cask', 'mas']
+      sudo: brewuser
 
 - brewfile:
     # This accepts the same options as `brew bundle` command:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ git submodule add https://github.com/sobolevn/dotbot-brewfile.git
       stdout: false
       stderr: false
       include: ['tap', 'brew', 'cask', 'mas']
+      # Optional, if you want to run install command as another user:
       sudo: brewuser
 
 - brewfile:

--- a/brewfile.py
+++ b/brewfile.py
@@ -81,10 +81,13 @@ class Brew(dotbot.Plugin):
                 return option
             return '%s=%s' % (option, value)
 
+        sudo_user = data.get('sudo')
+        if sudo_user:
+            command = f'sudo -Hu {sudo_user} {command}'
         options = [command]
 
         for key, value in data.items():
-            if key not in {'stdout', 'stderr', 'include'}:
+            if key not in {'stdout', 'stderr', 'include', 'sudo'}:
                 options.append(build_option(key, value))
         return ' '.join(options)
 

--- a/example.yaml
+++ b/example.yaml
@@ -8,3 +8,5 @@
     # Will print all output from brew
     stdout: true
     stderr: true
+    # Will run brew commands as another user
+    sudo: brewuser


### PR DESCRIPTION
This feature is helpful for using Homebrew on a multi-user system.
Please, see a [post](https://www.codejam.info/2021/11/homebrew-multi-user.html#the-good-dedicate-a-single-user-account-to-homebrew) for clarification of my point.